### PR TITLE
Round position on write, prevent false returning not busy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- round position on write
+- prevent case where busy would always be false
+
 ## [2022.5.0]
 
 ### Fixed

--- a/yaqd_acton/_acton_2150i.py
+++ b/yaqd_acton/_acton_2150i.py
@@ -31,7 +31,7 @@ class Acton2150I(HasTurret, UsesUart, UsesSerial, HasLimits, HasPosition, IsDaem
 
     def _set_position(self, position):
         self._busy = True
-        self.ser.write(f"{position} GOTO\r".encode())
+        self.ser.write(f"{round(position, 1)} GOTO\r".encode())
 
     def set_turret(self, identifier):
         self._busy = True
@@ -57,7 +57,10 @@ class Acton2150I(HasTurret, UsesUart, UsesSerial, HasLimits, HasPosition, IsDaem
                 await asyncio.sleep(1)
                 continue
             # assess busy state
-            if math.isclose(now, self._state["position"]):
+            if abs(now - self._state["destination"]) > 0.2:
+                self._busy = True
+                self._state["position"] = now
+            elif math.isclose(now, self._state["position"]):
                 self._busy = False
                 await self._busy_sig.wait()
             else:


### PR DESCRIPTION
This currently represents the fast fixes I did while working with our undergrad assistant.

I do not believe the fix for timing of busy status is complete... we probably want to check both this and the other acton mono implementation (which if it does have considerations for this problem may provide insight as to how to actually fix it easily)

Additionally we observered strange behavior when told to go to floating point positions e.g. sending `404.040404040404 GOTO` sent it into some strange routine, likely due to misinterpretting the decimal point or something (it seemed to go on forever requiring a hard power cycle to break out of)

The docs seem to indicate that it will go to the nearest 0.1 nm, though at least some values still seemed fine with more, so maybe we want to round to 2 or 3 decimal positions instead of the 1 as I wrote it here.
